### PR TITLE
Fix issue in Arrays::getNestedValue

### DIFF
--- a/src/Ouzo/Goodies/Utilities/Arrays.php
+++ b/src/Ouzo/Goodies/Utilities/Arrays.php
@@ -890,6 +890,10 @@ class Arrays
         if (count($keys) == 0) {
             unset($array[$key]);
         } elseif (isset($array[$key])) {
+            if (!is_array($array[$key])) {
+                return;
+            }
+
             self::removeNestedKey($array[$key], $keys, $removeEmptyParents);
             if ($removeEmptyParents && empty($array[$key])) {
                 unset($array[$key]);
@@ -928,7 +932,7 @@ class Arrays
     public static function hasNestedKey(array $array, array $keys, $flags = null)
     {
         foreach ($keys as $key) {
-            if (!array_key_exists($key, $array) || (!($flags & self::TREAT_NULL_AS_VALUE) && !isset($array[$key]))) {
+            if (!is_array($array) || !array_key_exists($key, $array) || (!($flags & self::TREAT_NULL_AS_VALUE) && !isset($array[$key]))) {
                 return false;
             }
             $array = self::getValue($array, $key);

--- a/src/Ouzo/Goodies/Utilities/Arrays.php
+++ b/src/Ouzo/Goodies/Utilities/Arrays.php
@@ -843,6 +843,10 @@ class Arrays
             if (!$array) {
                 return $array;
             }
+
+            if (!is_array($array) && self::last($keys) !== $key) {
+                return null;
+            }
         }
         return $array;
     }

--- a/test/src/Ouzo/Goodies/Utilities/ArraysTest.php
+++ b/test/src/Ouzo/Goodies/Utilities/ArraysTest.php
@@ -760,13 +760,43 @@ class ArraysTest extends TestCase
     /**
      * @test
      */
-    public function getNestedValueShouldReturnNullWhenZeroKeyNotFound()
+    public function getNestedValueShouldReturnNullWhenZeroStringKeyNotFound()
     {
         //given
         $array = ['1' => ['2' => ['3' => 'value']]];
 
         //when
         $value = Arrays::getNestedValue($array, ['1', '2', '3', '0']);
+
+        //then
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     */
+    public function getNestedValueShouldReturnNullWhenZeroIntKeyNotFound()
+    {
+        //given
+        $array = ['1' => ['2' => ['3' => 'value']]];
+
+        //when
+        $value = Arrays::getNestedValue($array, ['1', '2', '3', 0]);
+
+        //then
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     */
+    public function getNestedValueShouldReturnNullWhenMultipleStringZeroKeysNotFound()
+    {
+        //given
+        $array = ['1' => ['2' => ['3' => 'value']]];
+
+        //when
+        $value = Arrays::getNestedValue($array, ['1', '2', '3', '0', '0', '0']);
 
         //then
         $this->assertNull($value);
@@ -875,6 +905,21 @@ class ArraysTest extends TestCase
 
         //then
         $this->assertEquals(['1' => null], $array);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotChangeInputArrayWhenKeyNotFound()
+    {
+        //given
+        $array = ['1' => ['2' => ['3' => 'value']]];
+
+        //when
+        Arrays::removeNestedKey($array, ['1', '2', '3', '0']);
+
+        //then
+        $this->assertEquals(['1' => ['2' => ['3' => 'value']]], $array);
     }
 
     /**
@@ -994,6 +1039,21 @@ class ArraysTest extends TestCase
 
         //when
         $value = Arrays::hasNestedKey($array, ['1', '2', '3']);
+
+        //then
+        $this->assertFalse($value);
+    }
+
+    /**
+     * @test
+     */
+    public function hasNestedKeyShouldReturnFalseWhenKeyStringZeroDoesNotExist()
+    {
+        //given
+        $array = ['1' => ['2' => ['3' => 'value']]];
+
+        //when
+        $value = Arrays::hasNestedKey($array, ['1', '2', '3', '0']);
 
         //then
         $this->assertFalse($value);

--- a/test/src/Ouzo/Goodies/Utilities/ArraysTest.php
+++ b/test/src/Ouzo/Goodies/Utilities/ArraysTest.php
@@ -760,6 +760,21 @@ class ArraysTest extends TestCase
     /**
      * @test
      */
+    public function getNestedValueShouldReturnNullWhenZeroKeyNotFound()
+    {
+        //given
+        $array = ['1' => ['2' => ['3' => 'value']]];
+
+        //when
+        $value = Arrays::getNestedValue($array, ['1', '2', '3', '0']);
+
+        //then
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     */
     public function getNestedValueShouldReturnEmptyValue()
     {
         //given


### PR DESCRIPTION
Fix Arrays::getNestedValue in case when keys lead to non-existing element with scalar parent.

