### PR TITLE
Add Lambda - Suggestion, not sure if it makes sense.

### DIFF
--- a/src/Ouzo/Goodies/Utilities/Lambda.php
+++ b/src/Ouzo/Goodies/Utilities/Lambda.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright (c) Ouzo contributors, http://ouzoframework.org
+ * This file is made available under the MIT License (view the LICENSE file for more information).
+ */
+
+namespace Ouzo\Utilities;
+
+use Ouzo\Model;
+
+class Lambda
+{
+    public static function id()
+    {
+        return function (Model $object) {
+            return $object->getId();
+        };
+    }
+
+    public static function __callStatic(string $name, array $arguments)
+    {
+        return (new NonCallableExtractor())->$name(...$arguments);
+    }
+}

--- a/test/src/Ouzo/Goodies/Utilities/LambdaTest.php
+++ b/test/src/Ouzo/Goodies/Utilities/LambdaTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright (c) Ouzo contributors, http://ouzoframework.org
+ * This file is made available under the MIT License (view the LICENSE file for more information).
+ */
+
+use Ouzo\Model;
+use Ouzo\Tests\Assert;
+use Ouzo\Utilities\Functions;
+use Ouzo\Utilities\Lambda;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LambdaTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetId()
+    {
+        // given
+        $object = $this->mockModel(14);
+        $function = Lambda::id();
+
+        //when
+        $result = Functions::call($function, $object);
+
+        //then
+        Assert::that($result)->isEqualTo(14);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBindMethodParameters()
+    {
+        //given
+        $object = new ExtractorTestClass();
+        $function = Lambda::returnArgument('argument');
+
+        //when
+        $result = Functions::call($function, $object);
+
+        //then
+        Assert::thatString($result)->isEqualTo('argument');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldExtractFieldAfterMethod()
+    {
+        //given
+        $product = new ExtractorTestClass();
+        $object = (object)['name' => 'category'];
+
+        $function = Lambda::returnArgument($object)->name;
+
+        //when
+        $result = Functions::call($function, $product);
+
+        //then
+        Assert::thatString($result)->isEqualTo('category');
+    }
+
+    private function mockModel(int $id): Model
+    {
+        /** @var Model|MockObject $model */
+        $model = $this->createMock(Model::class);
+        $model->method('getId')->willReturn($id);
+        return $model;
+    }
+}


### PR DESCRIPTION
It would resemble how Java method reference works:
```java
MyClass::method == (MyClass c) -> c.method()
```
so would
```php
Lambda::method() == function (MyClass $c) { return $c->method(); }
```

Of course `Lambda::method()` is identical to `Functions::extract()->method()`.


*Downside is, you probably can't use dynamic return type plugin (or am I wrong?).*

*Not sure if this class is a good idea for the library, you decide.*
