### PR TITLE
Updates in ConfigTest.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: php
 
 php:
@@ -15,6 +14,9 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: nightly
+
+services:
+    - mysql
 
 addons:
     postgresql: "9.5"
@@ -38,7 +40,7 @@ before_script:
     - psql -v ON_ERROR_STOP=1 -e -U ouzo_user -f test/test-db/recreate_schema.sql ouzo_test
     - mysql -u travis -e 'create database ouzo_test' && cat test/test-db/recreate_schema_mysql.sql | mysql -u travis ouzo_test
     - cat test/test-db/recreate_schema_sqlite3.sql | sqlite3 ouzo_test
-    
+
 script:
     - if [[ "$db" == "sqlite3" ]]; then vendor/bin/phpunit -d zend.enable_gc=0 --configuration phpunit.xml --exclude-group non-sqlite3,postgres test; fi
     - if [[ "$db" == "postgres" ]]; then vendor/bin/phpunit --debug --verbose -d zend.enable_gc=0 --configuration phpunit.xml --exclude-group sqlite3 test; fi

--- a/test/src/Ouzo/Core/ConfigTest.php
+++ b/test/src/Ouzo/Core/ConfigTest.php
@@ -57,10 +57,10 @@ class ConfigTest extends TestCase
      */
     public function shouldReturnNullForMissingSections()
     {
-        //when
+        // when
         $section = Config::getValue('missing');
 
-        //then
+        // then
         $this->assertNull($section);
     }
 
@@ -69,14 +69,14 @@ class ConfigTest extends TestCase
      */
     public function shouldReadSampleConfig()
     {
-        //given
+        // given
         $configRepository = Config::registerConfig(new SampleConfig);
         $configRepository->reload();
 
-        //when
+        // when
         $value = Config::getValue('default');
 
-        //then
+        // then
         $this->assertEquals('SampleAuth', $value['auth']);
     }
 
@@ -85,13 +85,13 @@ class ConfigTest extends TestCase
      */
     public function shouldReturnConfigValue()
     {
-        //given
+        // given
         Config::registerConfig(new SampleConfig);
 
-        //when
+        // when
         $value = Config::getValue('default');
 
-        //then
+        // then
         $this->assertEquals('SampleAuth', $value['auth']);
     }
 
@@ -100,13 +100,13 @@ class ConfigTest extends TestCase
      */
     public function shouldReturnNestedConfigValue()
     {
-        //given
+        // given
         Config::registerConfig(new SampleConfig);
 
-        //when
+        // when
         $value = Config::getValue('default', 'auth');
 
-        //then
+        // then
         $this->assertEquals('SampleAuth', $value);
     }
 
@@ -115,16 +115,16 @@ class ConfigTest extends TestCase
      */
     public function shouldReadSampleConfigFromFile()
     {
-        //given
+        // given
         $this->_createSampleConfigFile();
         include_once '/tmp/SampleConfigFile.php';
         $configRepository = Config::registerConfig(new SampleConfigFile());
         $configRepository->reload();
 
-        //when
+        // when
         $value = Config::getValue('default');
 
-        //then
+        // then
         $this->assertEquals('SampleAuthFile', $value['auth']);
     }
 
@@ -133,7 +133,7 @@ class ConfigTest extends TestCase
      */
     public function shouldReadMultipleSampleConfigs()
     {
-        //given
+        // given
         $this->_createSampleConfigFile();
         /** @noinspection PhpIncludeInspection */
         include_once '/tmp/SampleConfigFile.php';
@@ -141,10 +141,10 @@ class ConfigTest extends TestCase
         Config::registerConfig(new SampleConfigFile);
         Config::registerConfig(new SampleConfig)->reload();
 
-        //when
+        // when
         $value = Config::getValue('default');
 
-        //then
+        // then
         $this->assertEquals('file', $value['file']);
         $this->assertEquals('class', $value['class']);
     }
@@ -242,8 +242,10 @@ TEMPLATE;
      */
     public function revertOnNonExistingKeyShouldThrowException()
     {
+        // then
         $this->expectException(InvalidArgumentException::class);
 
+        // when
         Config::revertProperty('key', 'does', 'not', 'exist');
     }
 
@@ -271,10 +273,10 @@ TEMPLATE;
         // given
         Config::overrideProperty('key')->with('value');
 
-        //when
+        // when
         $values = Config::all();
 
-        //then
+        // then
         $this->assertEquals('value', $values['key']);
         Config::clearProperty('key'); // cleanup
     }
@@ -284,10 +286,10 @@ TEMPLATE;
      */
     public function shouldOverrideConfigPropertyBySession()
     {
-        //when
+        // when
         $values = Config::all();
 
-        //then
+        // then
         Assert::thatArray($values)->containsKeyAndValue(['debug' => false, 'language' => 'pl', 'custom' => 'value']);
         Assert::thatArray($values['global'])->contains('/sample');
     }
@@ -297,9 +299,11 @@ TEMPLATE;
      */
     public function shouldThrowExceptionWhenConfigMethodIsNotAnObject()
     {
+        // then
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Custom config must be a object');
 
+        // when
         Config::registerConfig('config');
     }
 
@@ -308,9 +312,11 @@ TEMPLATE;
      */
     public function shouldThrowExceptionWhenTryToAddCustomConfigWithoutGetConfigMethod()
     {
+        // then
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Custom config object must have getConfig method');
 
+        // when
         Config::registerConfig(new NoGetConfigMethod());
     }
 
@@ -319,9 +325,11 @@ TEMPLATE;
      */
     public function shouldThrowExceptionWhenTryToAddCustomConfigWhenGetConfigMethodIsNotPublic()
     {
+        // then
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Custom config method getConfig must be public');
 
+        // when
         Config::registerConfig(new PrivateGetConfigMethod());
     }
 }

--- a/test/src/Ouzo/Core/ConfigTest.php
+++ b/test/src/Ouzo/Core/ConfigTest.php
@@ -53,9 +53,6 @@ class ConfigTest extends TestCase
         Config::overrideProperty('debug')->with(true);
         Config::overrideProperty('language')->with('en');
         Config::overridePropertyArray(['global', 'prefix_system'], '');
-        if (Files::exists('/tmp/SampleConfigFile.php')) {
-            unlink('/tmp/SampleConfigFile.php');
-        }
     }
 
     /**
@@ -118,57 +115,18 @@ class ConfigTest extends TestCase
     /**
      * @test
      */
-    public function shouldReadSampleConfigFromFile()
-    {
-        // given
-        $this->_createSampleConfigFile();
-        include_once '/tmp/SampleConfigFile.php';
-        $configRepository = Config::registerConfig(new SampleConfigFile());
-        $configRepository->reload();
-
-        // when
-        $value = Config::getValue('default');
-
-        // then
-        $this->assertEquals('SampleAuthFile', $value['auth']);
-    }
-
-    /**
-     * @test
-     */
     public function shouldReadMultipleSampleConfigs()
     {
         // given
-        $this->_createSampleConfigFile();
-        /** @noinspection PhpIncludeInspection */
-        include_once '/tmp/SampleConfigFile.php';
-        /** @noinspection PhpUndefinedClassInspection */
-        Config::registerConfig(new SampleConfigFile);
         Config::registerConfig(new SampleConfig(['lorem' => 'ipsum']))->reload();
+        Config::registerConfig(new SampleConfig(['dolor' => 'emet']))->reload();
 
         // when
         $value = Config::getValue('default');
 
         // then
-        $this->assertEquals('file', $value['file']);
         $this->assertEquals('ipsum', $value['lorem']);
-    }
-
-    private function _createSampleConfigFile()
-    {
-        $classTemplate = <<<'TEMPLATE'
-<?php
-class SampleConfigFile
-{
-    public function getConfig()
-    {
-        $config['default']['auth'] = 'SampleAuthFile';
-        $config['default']['file'] = 'file';
-        return $config;
-    }
-}
-TEMPLATE;
-        file_put_contents('/tmp/SampleConfigFile.php', $classTemplate);
+        $this->assertEquals('emet', $value['dolor']);
     }
 
     /**

--- a/test/src/Ouzo/Core/ConfigTest.php
+++ b/test/src/Ouzo/Core/ConfigTest.php
@@ -11,11 +11,17 @@ use PHPUnit\Framework\TestCase;
 
 class SampleConfig
 {
-    public function getConfig()
+    /** @var array */
+    private $values;
+
+    public function __construct(array $values)
     {
-        $config['default']['auth'] = 'SampleAuth';
-        $config['default']['class'] = 'class';
-        return $config;
+        $this->values = $values;
+    }
+
+    public function getConfig(): array
+    {
+        return ['default' => $this->values];
     }
 }
 
@@ -70,14 +76,13 @@ class ConfigTest extends TestCase
     public function shouldReadSampleConfig()
     {
         // given
-        $configRepository = Config::registerConfig(new SampleConfig);
-        $configRepository->reload();
+        Config::registerConfig(new SampleConfig(['foo' => 'bar']))->reload();
 
         // when
         $value = Config::getValue('default');
 
         // then
-        $this->assertEquals('SampleAuth', $value['auth']);
+        $this->assertEquals('bar', $value['foo']);
     }
 
     /**
@@ -86,13 +91,13 @@ class ConfigTest extends TestCase
     public function shouldReturnConfigValue()
     {
         // given
-        Config::registerConfig(new SampleConfig);
+        Config::registerConfig(new SampleConfig(['cat' => 'dog']))->reload();
 
         // when
         $value = Config::getValue('default');
 
         // then
-        $this->assertEquals('SampleAuth', $value['auth']);
+        $this->assertEquals('dog', $value['cat']);
     }
 
     /**
@@ -101,13 +106,13 @@ class ConfigTest extends TestCase
     public function shouldReturnNestedConfigValue()
     {
         // given
-        Config::registerConfig(new SampleConfig);
+        Config::registerConfig(new SampleConfig(['frodo' => 'bilbo']))->reload();
 
         // when
-        $value = Config::getValue('default', 'auth');
+        $value = Config::getValue('default', 'frodo');
 
         // then
-        $this->assertEquals('SampleAuth', $value);
+        $this->assertEquals('bilbo', $value);
     }
 
     /**
@@ -139,14 +144,14 @@ class ConfigTest extends TestCase
         include_once '/tmp/SampleConfigFile.php';
         /** @noinspection PhpUndefinedClassInspection */
         Config::registerConfig(new SampleConfigFile);
-        Config::registerConfig(new SampleConfig)->reload();
+        Config::registerConfig(new SampleConfig(['lorem' => 'ipsum']))->reload();
 
         // when
         $value = Config::getValue('default');
 
         // then
         $this->assertEquals('file', $value['file']);
-        $this->assertEquals('class', $value['class']);
+        $this->assertEquals('ipsum', $value['lorem']);
     }
 
     private function _createSampleConfigFile()

--- a/test/src/Ouzo/Core/ConfigTest.php
+++ b/test/src/Ouzo/Core/ConfigTest.php
@@ -139,7 +139,7 @@ class ConfigTest extends TestCase
         include_once '/tmp/SampleConfigFile.php';
         /** @noinspection PhpUndefinedClassInspection */
         Config::registerConfig(new SampleConfigFile);
-        Config::registerConfig(new SampleConfig);
+        Config::registerConfig(new SampleConfig)->reload();
 
         //when
         $value = Config::getValue('default');


### PR DESCRIPTION
 - Tests would fail on windows because of `/tmp` usage, but it turns out it's not even necessary.
   
   Tests would save `SampleConfigFile` class in `/tmp/SampleConfigFile.php`, because there once was `CustomConfig` that could load files, so to test that `/tmp/SampleConfigFile.php` was created for testing. Later, it was removed in favour of `SampleConfig`, but instead of removing `/tmp/SampleConfigFile.php`, it was left as it was, and then immediately `include_once`. Obviously this is unnecessary since the file isn't tested, only the class that's passed to `registerConfig()`. Without the file, the test doesn't need to operate on filesystem, so tests pass on windows.

- Tests were reliant on the order and the fact that multiple tests are run. If you run any test that uses `registerConfig()` but not `reload()` (so `shouldReadMultipleSampleConfigs()`, `shouldReadSampleConfig()`, `shouldReturnConfigValue()`), they would fail if you run them separately.

  Further more, because the config remembers the state between tests (`static` field), the tests are sometimes **false-positive**, so even if you remove the code from given/when it would pass, because other tests registered the config. They would be caught, if the tested values were different, but `SampleConfig` always returned the same value for each test, so each assertion passed.

  To fix it, I made `new SampleConfig()` into `new SampleConfig(['foo' => 'bar'])`, so each test recieves unique `key=>value` pair, and isn't prone to false positives from other configs.

Feel free to squash the commits while merging the PR.