### PR TITLE
Migrate phpunit.xml to PhpUnit 9.3+ schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project
 .idea/
+.composer/
 vendor/
 
 # PhpUnit

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,10 @@
 <phpunit bootstrap="bootstrap_test.php">
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+    <coverage>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging/>
     <groups>
         <exclude>
             <group>sqlite3</group>


### PR DESCRIPTION
I noticed ouzo uses `"phpunit/phpunit": "^9.4"`, and since PhpUnit 9.3 the schema changed.

You can read about it here: https://phpunit.readthedocs.io/en/9.3/configuration.html#the-report-element