### PR TITLE
Test against real data in `RouteFileGeneratorTest`, not just `strlen($data)`

### DIFF
--- a/test/src/Ouzo/Core/Routing/Generator/RouteFileGeneratorTest.php
+++ b/test/src/Ouzo/Core/Routing/Generator/RouteFileGeneratorTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Ouzo\Routing\Generator\RouteFileGenerator;
 use Ouzo\Routing\Loader\AnnotationClassLoader;
 use Ouzo\Routing\Loader\AnnotationDirectoryLoader;
+use Ouzo\Tests\Assert;
 use Ouzo\Utilities\Path;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +30,25 @@ class RouteFileGeneratorTest extends TestCase
         $result = $routeFileGenerator->generate($path, [__DIR__ . '/../Fixtures/Annotation']);
 
         //then
+        $string = file_get_contents($path);
+        $routeFile = <<<GENERATED
+<?php
+
+use Ouzo\Routing\Route;
+
+Route::get('/action', \Application\Model\Test\SimpleController::class, 'action');
+Route::post('/create', \Application\Model\Test\CrudController::class, 'post');
+Route::delete('/delete', \Application\Model\Test\CrudController::class, 'delete');
+Route::get('/get', \Application\Model\Test\MultipleMethods::class, 'getAndPost');
+Route::post('/post', \Application\Model\Test\MultipleMethods::class, 'getAndPost');
+Route::get('/prefix/', \Application\Model\Test\GlobalController::class, 'index');
+Route::post('/prefix/action', \Application\Model\Test\GlobalController::class, 'action');
+Route::get('/read', \Application\Model\Test\CrudController::class, 'get');
+Route::put('/update', \Application\Model\Test\CrudController::class, 'put');
+
+GENERATED;
         $this->assertIsInt($result);
-        $this->assertEquals($result, strlen(file_get_contents($path)));
+        Assert::thatString($result)->isEqualTo(strlen($string));
+        Assert::thatString($string)->isEqualTo($routeFile);
     }
 }


### PR DESCRIPTION
Test `RouteFileGeneratorTest` only checked `strlen($expected) == strlen($actual)` which could lead to many false positives. 

For example, when I removed the file logic and added `return 0;` the test passed :|