### PR TITLE
Add a failing test for FluentArray.values()

### DIFF
--- a/src/Ouzo/Goodies/Utilities/Arrays.php
+++ b/src/Ouzo/Goodies/Utilities/Arrays.php
@@ -7,6 +7,7 @@
 namespace Ouzo\Utilities;
 
 use InvalidArgumentException;
+use function array_values;
 
 class Arrays
 {
@@ -1144,5 +1145,43 @@ class Arrays
     public static function getDuplicatesAssoc(array $array): array
     {
         return array_unique(array_intersect($array, array_diff_assoc($array, array_unique($array))));
+    }
+
+    /**
+     * Returns only values from an array.
+     * Example:
+     * <code>
+     * $result = Arrays::values(['red' => 'apple', 'green' => 'pear']);
+     * </code>
+     * Result:
+     * <code>
+     * Array (
+     *      [0] => 'apple'
+     *      [1] => 'pear'
+     * )
+     * </code>
+     */
+    public static function values(array $array): array
+    {
+        return array_slice(array_values($array), 0);
+    }
+
+    /**
+     * Returns only keys from an array.
+     * Example:
+     * <code>
+     * $result = Arrays::keys(['red' => 'apple', 'green' => 'pear']);
+     * </code>
+     * Result:
+     * <code>
+     * Array (
+     *      [0] => 'red'
+     *      [1] => 'green'
+     * )
+     * </code>
+     */
+    public static function keys(array $array): array
+    {
+        return array_keys($array);
     }
 }

--- a/src/Ouzo/Goodies/Utilities/FluentArray.php
+++ b/src/Ouzo/Goodies/Utilities/FluentArray.php
@@ -97,13 +97,13 @@ class FluentArray
 
     public function keys(): static
     {
-        $this->array = array_keys($this->array);
+        $this->array = Arrays::keys($this->array);
         return $this;
     }
 
     public function values(): static
     {
-        $this->array = array_values($this->array);
+        $this->array = Arrays::values($this->array);
         return $this;
     }
 

--- a/test/src/Ouzo/Goodies/Utilities/ArraysTest.php
+++ b/test/src/Ouzo/Goodies/Utilities/ArraysTest.php
@@ -1319,4 +1319,50 @@ class ArraysTest extends TestCase
         $this->assertEmpty(Arrays::getDuplicatesAssoc(['a', 'b', 'c']));
         $this->assertEmpty(Arrays::getDuplicatesAssoc([]));
     }
+
+    /**
+     * @test
+     */
+    public function shouldGetValues()
+    {
+        //given
+        $array = ['id' => 4, 'name' => 'Arya', 'surname' => 'Stark'];
+
+        //when
+        $keys = Arrays::values($array);
+
+        //then
+        Assert::thatArray($keys)->isEqualTo([4, 'Arya', 'Stark']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldResetInternalArrayPointer()
+    {
+        //given
+        $array = ['one', 'two', 'three'];
+        next($array);
+
+        //when
+        $values = Arrays::values($array);
+
+        //then
+        $this->assertEquals('one', current($values));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetKeys()
+    {
+        //given
+        $array = ['id' => 4, 'name' => 'Arya', 'surname' => 'Stark'];
+
+        //when
+        $keys = Arrays::keys($array);
+
+        //then
+        Assert::thatArray($keys)->isEqualTo(['id', 'name', 'surname']);
+    }
 }

--- a/test/src/Ouzo/Goodies/Utilities/FluentArrayTest.php
+++ b/test/src/Ouzo/Goodies/Utilities/FluentArrayTest.php
@@ -366,4 +366,37 @@ class FluentArrayTest extends TestCase
         //then
         $this->assertEquals([1 => 'b', 3 => 'c'], $result);
     }
+
+    /**
+     * @test
+     * @dataProvider associativeAndSequentialValueArrays
+     */
+    public function shouldValuesResetInternalArrayPointer(array $inputArray)
+    {
+        // given
+        next($inputArray);
+
+        // when
+        $copiedArray = FluentArray::from($inputArray)->values()->toArray();
+
+        // then
+        $this->assertEquals('two', current($inputArray));
+        $this->assertEquals('one', current($copiedArray));
+    }
+
+    public function associativeAndSequentialValueArrays(): array
+    {
+        return [
+            'associative' => [[
+                'one' => 'one',
+                'two' => 'two',
+                'three' => 'three'
+            ]],
+            'sequential' => [[
+                'one',
+                'two',
+                'three'
+            ]],
+        ];
+    }
 }


### PR DESCRIPTION
I recently found out that `array_values()` works differently for sequential and associative arrays.

I noticed that for some arrays `array_values()` rests internal array pointer, and for some it doesn't. Turns out, that `array_values()` only creates a new array if *would* be different. Sequential arrays would always be the same, so `array_values()` doesn't copy it, so the internal pointer is preserved.

I've written a failing unit test, you can see it's behaviour on the screen:

![image](https://user-images.githubusercontent.com/13367735/116251193-bdf31e00-a76e-11eb-9816-729ac308cbbf.png)

PS: What's funny, is that `array_keys()` and other methods don't have this behaviour, it's only `array_values()`. 
PS2: Perhaps apart from `FluentArrays.values()` also `Arrays.values()` could be added, which always returns a new array.
