### PR TITLE
Catch Throwable instead of Exception in Db::runInTransaction()

### DIFF
--- a/src/Ouzo/Core/Db.php
+++ b/src/Ouzo/Core/Db.php
@@ -7,13 +7,13 @@
 namespace Ouzo;
 
 use Closure;
-use Exception;
 use Ouzo\Db\PDOExceptionExtractor;
 use Ouzo\Db\StatementExecutor;
 use Ouzo\Db\TransactionalProxy;
 use Ouzo\Utilities\Arrays;
 use PDO;
 use PDOException;
+use Throwable;
 
 
 class Db
@@ -90,7 +90,7 @@ class Db
                 $result = call_user_func($callable);
                 $this->commitTransaction();
                 return $result;
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $this->rollbackTransactionSilently();
                 throw $e;
             }
@@ -126,7 +126,7 @@ class Db
     {
         try {
             $this->rollbackTransaction();
-        } catch (Exception) {
+        } catch (Throwable) {
         }
     }
 

--- a/test/src/Ouzo/Core/DbTest.php
+++ b/test/src/Ouzo/Core/DbTest.php
@@ -62,10 +62,10 @@ class DbTest extends DbTransactionalTestCase
         $db->dbHandle = $dbHandle;
 
         //when
-        CatchException::when($db)->runInTransaction(fn() => throw new InvalidArgumentException());
+        CatchException::when($db)->runInTransaction(fn() => throw new Error());
 
         //then
-        CatchException::assertThat()->isInstanceOf('InvalidArgumentException');
+        CatchException::assertThat()->isInstanceOf('Error');
         Mock::verify($dbHandle)->beginTransaction();
         Mock::verify($dbHandle)->neverReceived()->commitTransaction();
         Mock::verify($dbHandle)->rollBack();


### PR DESCRIPTION
`runInTransaction()` catches only **Exception**, which does not cover PHP's Error hierarchy (TypeError, ValueError, UnhandledMatchError, etc.). When an Error is thrown inside the transaction callable:

  1. The catch block is skipped — no rollback is performed
  2. $startedTransaction remains true
  3. All subsequent calls to runInTransaction() see $startedTransaction === true and skip BEGIN/COMMIT, executing the callable within the orphaned, never-committed transaction
  4. When the connection is eventually closed, the database rolls back all operations silently

  This leads to silent data loss — SQL statements (INSERT, UPDATE, DELETE) appear to execute successfully, but their effects are rolled back when the process ends.

  Without this fix, any Error thrown inside a runInTransaction() callable corrupts the connection's transaction state for the entire lifetime of the Db singleton. This is particularly dangerous in long-running processes (daemons, queue workers) where a single TypeError can cause all subsequent database
  writes to be silently lost.
