### PR TITLE
Exclude E_USER_DEPRECATED from error handler mask

### DIFF
--- a/src/Ouzo/Core/ExceptionHandling/ErrorHandler.php
+++ b/src/Ouzo/Core/ExceptionHandling/ErrorHandler.php
@@ -18,7 +18,7 @@ class ErrorHandler
     public function register(): void
     {
         set_exception_handler(fn(Throwable $exception) => $this->handleException($exception));
-        set_error_handler(fn(...$args) => $this->handleError(...$args), E_ALL & ~E_DEPRECATED);
+        set_error_handler(fn(...$args) => $this->handleError(...$args), E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
         register_shutdown_function(fn() => $this->handleShutdown());
     }
 


### PR DESCRIPTION
## Problem

`ErrorHandler::register()` used the mask `E_ALL & ~E_DEPRECATED`, which only excludes `E_DEPRECATED` (8192 — PHP engine deprecations). `E_USER_DEPRECATED` (16384) is a separate bit emitted by userland code via `trigger_error($msg, E_USER_DEPRECATED)`.

Because `E_USER_DEPRECATED` fell through the mask, `handleError()` received it and threw an `ErrorException`, turning a deprecation notice from third-party libraries (e.g. `symfony/deprecation-contracts`, used by `microsoft/azure-storage-common`) into a fatal HTTP 500 error.

## Fix

Added `& ~E_USER_DEPRECATED` to the error handler mask in `ErrorHandler::register()`.

```php
// before
set_error_handler(..., E_ALL & ~E_DEPRECATED);

// after
set_error_handler(..., E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
```